### PR TITLE
Prepare for publishing

### DIFF
--- a/lib/src/apis/keygen_entitlements_api.dart
+++ b/lib/src/apis/keygen_entitlements_api.dart
@@ -1,5 +1,5 @@
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 
 /// Entitlements can be attached to policies and to licenses to grant named
 /// "permissions" for things such as application features.

--- a/lib/src/apis/keygen_licenses_api.dart
+++ b/lib/src/apis/keygen_licenses_api.dart
@@ -1,5 +1,5 @@
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 
 /// A license is an implementation of a product's policy.
 ///

--- a/lib/src/apis/keygen_machines_api.dart
+++ b/lib/src/apis/keygen_machines_api.dart
@@ -1,5 +1,5 @@
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 
 /// Machines can be used to track and manage where your users are allowed to use your product.
 ///

--- a/lib/src/apis/keygen_misc_api.dart
+++ b/lib/src/apis/keygen_misc_api.dart
@@ -1,5 +1,5 @@
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 
 /// Miscellaneous actions.
 class KeygenMiscApi {

--- a/lib/src/apis/keygen_policies_api.dart
+++ b/lib/src/apis/keygen_policies_api.dart
@@ -1,5 +1,5 @@
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 
 /// Your policies define the different types of licenses that a given product offers.
 ///

--- a/lib/src/apis/keygen_products_api.dart
+++ b/lib/src/apis/keygen_products_api.dart
@@ -1,5 +1,5 @@
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 
 /// The product resource is used to segment policies and licenses by product, in the case where you sell multiple products.
 ///

--- a/lib/src/apis/keygen_tokens_api.dart
+++ b/lib/src/apis/keygen_tokens_api.dart
@@ -1,5 +1,5 @@
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 
 /// Keygen authenticates your API requests using tokens.
 ///

--- a/lib/src/apis/keygen_users_api.dart
+++ b/lib/src/apis/keygen_users_api.dart
@@ -1,5 +1,5 @@
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 
 /// Keygen provides identity management for your customers,
 /// which allows you to authenticate them using an email/password by creating a token.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: keygen
+name: runtime_keygen_sdk
 description: Dart package for Keygen (https://keygen.sh)
 
 version: 1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,8 @@
 name: runtime_keygen_sdk
 description: Dart package for Keygen (https://keygen.sh)
 
+homepage: 'https://github.com/open-runtime/runtime_keygen_sdk'
+
 version: 1.0.0
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,15 +9,10 @@ environment:
   sdk: ^3.4.3
 
 dependencies:
-  runtime_keygen_openapi:
-    git:
-      url: git@github.com:open-runtime/runtime_keygen_openapi.git
-      path: ./dart/
+  runtime_keygen_openapi: ^1.0.0
 
 dev_dependencies:
   lints: ^3.0.0
   test: ^1.24.0
   dotenv: ^4.2.0
-  runtime_digital_fingerprint:
-    git:
-      url: git@github.com:open-runtime/runtime_digital_fingerprint.git
+  runtime_digital_fingerprint: ^1.0.0

--- a/test/keygen_entitlement_test.dart
+++ b/test/keygen_entitlement_test.dart
@@ -1,6 +1,6 @@
 import 'package:dotenv/dotenv.dart';
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 import 'package:test/test.dart';
 
 

--- a/test/keygen_license_test.dart
+++ b/test/keygen_license_test.dart
@@ -1,6 +1,6 @@
 import 'package:dotenv/dotenv.dart';
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 import 'package:test/test.dart';
 
 

--- a/test/keygen_machine_test.dart
+++ b/test/keygen_machine_test.dart
@@ -1,7 +1,7 @@
 import 'package:dotenv/dotenv.dart';
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_digital_fingerprint/runtime_digital_fingerprint.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 import 'package:test/test.dart';
 
 

--- a/test/keygen_misc_test.dart
+++ b/test/keygen_misc_test.dart
@@ -1,6 +1,6 @@
 import 'package:dotenv/dotenv.dart';
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 import 'package:test/test.dart';
 
 

--- a/test/keygen_policy_test.dart
+++ b/test/keygen_policy_test.dart
@@ -1,6 +1,6 @@
 import 'package:dotenv/dotenv.dart';
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 import 'package:test/test.dart';
 
 

--- a/test/keygen_product_test.dart
+++ b/test/keygen_product_test.dart
@@ -1,6 +1,6 @@
 import 'package:dotenv/dotenv.dart';
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 import 'package:test/test.dart';
 
 

--- a/test/keygen_token_test.dart
+++ b/test/keygen_token_test.dart
@@ -1,6 +1,6 @@
 import 'package:dotenv/dotenv.dart';
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 import 'package:test/test.dart';
 
 

--- a/test/keygen_user_test.dart
+++ b/test/keygen_user_test.dart
@@ -1,6 +1,6 @@
 import 'package:dotenv/dotenv.dart';
-import 'package:keygen/runtime_keygen_sdk.dart';
 import 'package:runtime_keygen_openapi/api.dart';
+import 'package:runtime_keygen_sdk/runtime_keygen_sdk.dart';
 import 'package:test/test.dart';
 
 


### PR DESCRIPTION
Address issues from `dart pub publish --dry-run` that were not being shown until the dependencies (runtime_keygen_openapi and runtime_digital_fingerprint) were properly published.